### PR TITLE
Fix NPE on Navigation

### DIFF
--- a/app/src/main/java/org/cssnr/zipline/ui/files/FilesFragment.kt
+++ b/app/src/main/java/org/cssnr/zipline/ui/files/FilesFragment.kt
@@ -281,35 +281,36 @@ class FilesFragment : Fragment() {
                 Log.d("File[refreshLayout]", "onRefresh")
                 lifecycleScope.launch {
                     Log.d("File[refreshLayout]", "START")
-                    // TODO: Update binding as it can become null if the user navigates away...
-                    viewModel.selected.value = mutableSetOf<Int>()
-                    filesAdapter.selected.clear()
-                    Log.i("File[refreshLayout]", "3 - getFiles: ON REFRESH")
-                    getFiles(perPage, true)
-                    binding.refreshLayout.isRefreshing = false
-                    //binding.refreshLayout.isEnabled = false
-                    Log.d("File[refreshLayout]", "DONE")
-                    // Fade In
-                    binding.refreshBanner.post {
-                        binding.refreshBanner.translationY = -binding.refreshBanner.height.toFloat()
-                        binding.refreshBanner.visibility = View.VISIBLE
-                        binding.refreshBanner.animate()
-                            .alpha(1f)
-                            .translationY(0f)
-                            .setDuration(400)
-                            .start()
+
+                    _binding?.let {
+                        Log.d("File[refreshLayout]", "Binding is valid, starting refresh logic")
+                        viewModel.selected.value = mutableSetOf<Int>()
+                        filesAdapter.selected.clear()
+                        Log.i("File[refreshLayout]", "Fetching files on refresh")
+                        getFiles(perPage, true)
+                        it.refreshLayout.isRefreshing = false
+
+                        it.refreshBanner.post {
+                            Log.d("File[refreshLayout]", "Animating refresh banner fade-in")
+                            it.refreshBanner.translationY = -it.refreshBanner.height.toFloat()
+                            it.refreshBanner.visibility = View.VISIBLE
+                            it.refreshBanner.animate()
+                                .alpha(1f)
+                                .translationY(0f)
+                                .setDuration(400)
+                                .start()
+                        }
+
+                        Handler(Looper.getMainLooper()).postDelayed({
+                            Log.d("File[refreshLayout]", "Animating refresh banner fade-out")
+                            it.refreshBanner.animate()
+                                .alpha(0f)
+                                .translationY(-it.refreshBanner.height.toFloat())
+                                .setDuration(400)
+                                .withEndAction { it.refreshBanner.visibility = View.GONE }
+                                .start()
+                        }, 1600)
                     }
-                    Handler(Looper.getMainLooper()).postDelayed({
-                        // Fade Out
-                        binding.refreshBanner.animate()
-                            .alpha(0f)
-                            .translationY(-binding.refreshBanner.height.toFloat())
-                            .setDuration(400)
-                            .withEndAction {
-                                binding.refreshBanner.visibility = View.GONE
-                            }
-                            .start()
-                    }, 1600)
                 }
             }
         })
@@ -580,6 +581,7 @@ class FilesFragment : Fragment() {
 
     override fun onPause() {
         Log.d("File[onPause]", "ON PAUSE")
+        _binding?.refreshLayout?.isRefreshing = false
         super.onPause()
     }
 

--- a/app/src/main/java/org/cssnr/zipline/ui/files/FilesFragment.kt
+++ b/app/src/main/java/org/cssnr/zipline/ui/files/FilesFragment.kt
@@ -281,13 +281,7 @@ class FilesFragment : Fragment() {
                 Log.d("File[refreshLayout]", "onRefresh")
                 lifecycleScope.launch {
                     Log.d("File[refreshLayout]", "START")
-
-                    //Log.d("File[refreshLayout]", "Get Albums in the Background...")
-                    //launch(Dispatchers.IO) {
-                    //    ctx.getAlbums(savedUrl)
-                    //}
-
-                    //viewModel.selected.value?.clear()
+                    // TODO: Update binding as it can become null if the user navigates away...
                     viewModel.selected.value = mutableSetOf<Int>()
                     filesAdapter.selected.clear()
                     Log.i("File[refreshLayout]", "3 - getFiles: ON REFRESH")
@@ -573,7 +567,7 @@ class FilesFragment : Fragment() {
             }
         }
         Log.d("loadingSpinner", "loadingSpinner: View.GONE")
-        binding.loadingSpinner.visibility = View.GONE
+        _binding?.loadingSpinner?.visibility = View.GONE
         if (errorCount > 5) {
             atEnd = true
             viewModel.atEnd.value = atEnd


### PR DESCRIPTION
- Fix Crash when navigation away from files list while co-routines are running

https://console.firebase.google.com/project/zipline-android-client/crashlytics/app/android:org.cssnr.zipline/issues/b17c6ee35095983ea5f289732b726d37?time=last-seven-days&types=crash&sessionEventKey=68743760019A0001516AA9D00F8DDF42_2105147563381023233

```
Fatal Exception: java.lang.NullPointerException:
       at org.cssnr.zipline.ui.files.FilesFragment.getBinding(FilesFragment.java:49)
       at org.cssnr.zipline.ui.files.FilesFragment.access$getBinding(FilesFragment.java:46)
       at org.cssnr.zipline.ui.files.FilesFragment$onViewCreated$8$onRefresh$1.invokeSuspend$lambda$2(FilesFragment.java:310)
       at android.os.Handler.handleCallback(Handler.java:938)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loopOnce(Looper.java:226)
       at android.os.Looper.loop(Looper.java:313)
       at android.app.ActivityThread.main(ActivityThread.java:8663)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:567)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1135)
```