### PR TITLE
Fix Bug in Headers

### DIFF
--- a/app/src/main/java/org/cssnr/zipline/ui/settings/headers/HeadersFragment.kt
+++ b/app/src/main/java/org/cssnr/zipline/ui/settings/headers/HeadersFragment.kt
@@ -189,7 +189,7 @@ class HeadersFragment : Fragment() {
                     inputValue.error = "Required"
                     if (success) {
                         inputValue.requestFocus()
-                        inputValue.setSelection(inputKey.text.length)
+                        inputValue.setSelection(inputValue.text.length)
                     }
                     success = false
                 }


### PR DESCRIPTION
- Fix Headers Dialog Bug

https://console.firebase.google.com/project/zipline-android-client/crashlytics/app/android:org.cssnr.zipline/issues/053a28b2cd5dc948753b580a2de4ff61?time=last-seven-days&types=crash&sessionEventKey=6886049F01FE000105046A514844FC20_2110158904331170772

```
Fatal Exception: java.lang.IndexOutOfBoundsException: setSpan (5 ... 5) ends beyond length 0
       at android.text.SpannableStringBuilder.checkRange(SpannableStringBuilder.java:1326)
       at android.text.SpannableStringBuilder.setSpan(SpannableStringBuilder.java:685)
       at android.text.SpannableStringBuilder.setSpan(SpannableStringBuilder.java:677)
       at androidx.emoji2.text.SpannableBuilder.setSpan(SpannableBuilder.java:140)
       at android.text.Selection.setSelection(Selection.java:95)
       at android.text.Selection.setSelection(Selection.java:79)
       at android.text.Selection.setSelection(Selection.java:154)
       at android.widget.EditText.setSelection(EditText.java:198)
       at org.cssnr.zipline.ui.settings.headers.HeadersFragment.showHeadersDialog$lambda$9$lambda$8(HeadersFragment.java:192)
       at android.view.View.performClick(View.java:7931)
       at com.google.android.material.button.MaterialButton.performClick(MaterialButton.java:1218)
       at android.view.View.performClickInternal(View.java:7908)
       at android.view.View.-$$Nest$mperformClickInternal()
       at android.view.View$PerformClick.run(View.java:30990)
       at android.os.Handler.handleCallback(Handler.java:959)
       at android.os.Handler.dispatchMessage(Handler.java:100)
       at android.os.Looper.loopOnce(Looper.java:232)
       at android.os.Looper.loop(Looper.java:317)
       at android.app.ActivityThread.main(ActivityThread.java:8592)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:580)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:878)
```