### PR TITLE
Fix Crash on Login Page

### DIFF
--- a/app/src/main/java/org/cssnr/zipline/ui/setup/LoginFragment.kt
+++ b/app/src/main/java/org/cssnr/zipline/ui/setup/LoginFragment.kt
@@ -153,7 +153,7 @@ class LoginFragment : Fragment() {
                 binding.loginHostname.error = "Required"
                 valid = false
             }
-            if (valid && !isURL(host)) {
+            if (valid && host.toHttpUrlOrNull() == null) {
                 binding.loginHostname.error = "Invalid Host"
                 valid = false
             }
@@ -179,7 +179,6 @@ class LoginFragment : Fragment() {
                     Log.d("loginButton", "LOGIN FAILED")
                     _binding?.loginError?.visibility = View.VISIBLE
                     _binding?.loginError?.text = auth.error
-                    //Toast.makeText(ctx, "Login Failed!", Toast.LENGTH_SHORT).show()
                     val shake = ObjectAnimator.ofFloat(
                         _binding?.loginButton, "translationX",
                         0f, 25f, -25f, 20f, -20f, 15f, -15f, 6f, -6f, 0f
@@ -248,17 +247,6 @@ class LoginFragment : Fragment() {
         if (url.endsWith("/")) {
             url = url.substring(0, url.length - 1)
         }
-        //if (!Patterns.WEB_URL.matcher(url).matches()) {
-        //    Log.d("parseHost", "Patterns.WEB_URL.matcher Failed")
-        //    return ""
-        //}
         return url
     }
-
-    fun isURL(url: String): Boolean {
-        val result = url.toHttpUrlOrNull() != null
-        Log.d("isURL", "${if (result) "TRUE" else "FALSE"}: $url")
-        return result
-    }
-
 }


### PR DESCRIPTION
- Fix NPE on Binding in Coroutine on LoginFragment

https://console.firebase.google.com/project/zipline-android-client/crashlytics/app/android:org.cssnr.zipline/issues/8f09e987022b676d838880083982b85c?time=last-seven-days&types=crash&sessionEventKey=6888405E007F00011E712557EDEAEB4D_2110787605183199173

```
Fatal Exception: java.lang.NullPointerException:
       at org.cssnr.zipline.ui.setup.LoginFragment.getBinding(LoginFragment.java:36)
       at org.cssnr.zipline.ui.setup.LoginFragment.access$getBinding(LoginFragment.java:33)
       at org.cssnr.zipline.ui.setup.LoginFragment$onViewCreated$4$1.invokeSuspend(LoginFragment.kt:180)
       at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
       at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:99)
       at android.os.Handler.handleCallback(Handler.java:942)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loopOnce(Looper.java:201)
       at android.os.Looper.loop(Looper.java:288)
       at android.app.ActivityThread.main(ActivityThread.java:7872)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
```