### PR TITLE
Update Firebase

### DIFF
--- a/app/src/main/java/org/cssnr/zipline/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/cssnr/zipline/ui/settings/SettingsFragment.kt
@@ -28,8 +28,8 @@ import androidx.preference.SwitchPreferenceCompat
 import androidx.work.WorkManager
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import com.google.firebase.analytics.ktx.analytics
-import com.google.firebase.ktx.Firebase
+import com.google.firebase.analytics.analytics
+import com.google.firebase.Firebase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext

--- a/app/src/main/java/org/cssnr/zipline/ui/setup/LoginFragment.kt
+++ b/app/src/main/java/org/cssnr/zipline/ui/setup/LoginFragment.kt
@@ -25,8 +25,8 @@ import androidx.navigation.NavOptions
 import androidx.navigation.fragment.findNavController
 import androidx.preference.PreferenceManager
 import com.google.android.material.bottomnavigation.BottomNavigationView
-import com.google.firebase.analytics.ktx.analytics
-import com.google.firebase.ktx.Firebase
+import com.google.firebase.analytics.analytics
+import com.google.firebase.Firebase
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async

--- a/app/src/main/java/org/cssnr/zipline/ui/upload/UploadFragment.kt
+++ b/app/src/main/java/org/cssnr/zipline/ui/upload/UploadFragment.kt
@@ -36,8 +36,8 @@ import androidx.navigation.fragment.findNavController
 import androidx.preference.PreferenceManager
 import com.bumptech.glide.Glide
 import com.google.android.material.bottomnavigation.BottomNavigationView
-import com.google.firebase.analytics.ktx.analytics
-import com.google.firebase.ktx.Firebase
+import com.google.firebase.analytics.analytics
+import com.google.firebase.Firebase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "8.10.1"
 kotlin = "2.1.21"
 ksp = "2.1.21-2.0.1"
-coreKtx = "1.16.0"
+coreKtx = "1.17.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"
@@ -21,7 +21,7 @@ room = "2.7.2"
 webkit = "1.14.0"
 
 googleServices = "4.4.3"
-firebaseBom = "33.16.0"
+firebaseBom = "34.1.0"
 crashlyticsPlugin = "3.0.6"
 
 okhttp = "4.12.0"


### PR DESCRIPTION
- Update Firebase to >=34
- Remove Firebase ktx

This crash is not in the application, but in Firebase. Nevertheless this should help.

https://console.firebase.google.com/project/zipline-android-client/crashlytics/app/android:org.cssnr.zipline/issues/bf0aa132fee08d894d95a404d1a44d14?time=last-seven-days&types=crash&sessionEventKey=689E4A7200ED00011E38857A548EFA5D_2116991790891536809

```
Fatal Exception: android.app.RemoteServiceException$ForegroundServiceDidNotStartInTimeException: Context.startForegroundService() did not then call Service.startForeground(): ServiceRecord{43c201 u0 org.cssnr.zipline/com.google.android.gms.measurement.AppMeasurementService}
       at android.app.ActivityThread.generateForegroundServiceDidNotStartInTimeException(ActivityThread.java:2005)
       at android.app.ActivityThread.throwRemoteServiceException(ActivityThread.java:1976)
       at android.app.ActivityThread.-$$Nest$mthrowRemoteServiceException()
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2241)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loopOnce(Looper.java:201)
       at android.os.Looper.loop(Looper.java:288)
       at android.app.ActivityThread.main(ActivityThread.java:7872)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
```