### PR TITLE
Fix Crash on User Refresh

### DIFF
--- a/app/src/main/java/org/cssnr/zipline/ui/user/UserFragment.kt
+++ b/app/src/main/java/org/cssnr/zipline/ui/user/UserFragment.kt
@@ -283,7 +283,13 @@ class UserFragment : Fragment() {
                 Log.d(LOG_TAG, "binding.updateProfile - user: $user")
                 viewModel.user.value = user
                 _binding?.updateProfile?.isEnabled = true
-                Snackbar.make(view, "Profile Refreshed from Server.", Snackbar.LENGTH_SHORT).show()
+                if (user == null) {
+                    Snackbar.make(view, "Error Refreshing Profile!", Snackbar.LENGTH_LONG)
+                        .setTextColor("#D32F2F".toColorInt()).show()
+                } else {
+                    Snackbar.make(view, "Profile Refreshed from Server.", Snackbar.LENGTH_SHORT)
+                        .show()
+                }
             }
         }
 

--- a/app/src/main/java/org/cssnr/zipline/ui/user/UserFragment.kt
+++ b/app/src/main/java/org/cssnr/zipline/ui/user/UserFragment.kt
@@ -122,6 +122,7 @@ class UserFragment : Fragment() {
 
         viewModel.user.observe(viewLifecycleOwner) { user ->
             Log.i(LOG_TAG, "viewModel.user.observe - user: $user")
+            if (user == null) return@observe
 
             val totpEnabled = user.totpSecret?.isNotEmpty() == true
             Log.i(LOG_TAG, "totpEnabled: $totpEnabled")
@@ -154,6 +155,7 @@ class UserFragment : Fragment() {
 
         viewModel.server.observe(viewLifecycleOwner) { server ->
             Log.i(LOG_TAG, "viewModel.server.observe - server: $server")
+            if (server == null) return@observe
             binding.stats.filesCount.text = server.filesUploaded.toString()
 
             binding.stats.filesSize.text =


### PR DESCRIPTION
Fix a crash on the User page where tapping "Refresh Profile" after a failed or empty API call set a null user into the data.